### PR TITLE
fix test failure

### DIFF
--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -8,6 +8,13 @@ import unittest
 import markdown
 
 class TestCase(unittest.TestCase):
+    def setUp(self):
+        self.has_pygments = True
+        try:
+            import pygments  # noqa
+        except ImportError:
+            self.has_pygments = False
+
     def assert_renders(self, expected, source, extensions):
         """Asserts that one markdown string renders as expected.
 

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -6,14 +6,22 @@ from test_case import TestCase
 
 class TestGfm(TestCase):
     def test_fenced_code(self):
-        self.assert_renders("""
-        <div class="highlight"><pre>foo
-        </pre></div>
-        """, """
+        test_text = """
         ```
         foo
         ```
-        """, ['gfm'])
+        """
+        extensions = ['gfm']
+        if self.has_pygments:
+            self.assert_renders("""
+        <div class="highlight"><pre>foo
+        </pre></div>
+        """, test_text, extensions)
+        else:
+            self.assert_renders("""
+        <pre class="highlight"><code>foo</code></pre>
+        """, test_text, extensions)
+            
 
     def test_nl2br(self):
         self.assert_renders("""

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -59,14 +59,22 @@ class TestGfm(TestCase):
         """, ['gfm'])
 
     def test_hilite(self):
-        self.assert_renders("""
-        <div class="highlight"><pre><span class="k">def</span>
-        </pre></div>
-        """, """
+        test_text = """
         ```.python
         def
         ```
-        """, ['gfm'])
+        """
+        extensions = ['gfm']
+
+        if self.has_pygments:
+            self.assert_renders("""
+        <div class="highlight"><pre><span class="k">def</span>
+        </pre></div>
+        """, test_text, extensions)
+        else:
+            self.assert_renders("""
+        <pre class="highlight"><code class="language-python">def</code></pre>
+        """, test_text, extensions)
 
     def test_semi_sane_lists(self):
         self.assert_renders("""

--- a/tests/test_hidden_hilite.py
+++ b/tests/test_hidden_hilite.py
@@ -8,6 +8,7 @@ from test_case import TestCase
 
 class TestHiddenHilite(TestCase):
     def setUp(self):
+        TestCase.setUp(self)
         self.hidden_hilite = gfm.HiddenHiliteExtension([])
 
     def test_doesnt_highlight_code_blocks(self):
@@ -39,11 +40,18 @@ class TestHiddenHilite(TestCase):
         """, [self.hidden_hilite])
 
     def test_does_highlight_fenced_blocks(self):
-        self.assert_renders("""
-        <div class="codehilite"><pre><span class="k">def</span>
-        </pre></div>
-        """, """
+        test_text = """
         ```python
         def
         ```
-        """, [self.hidden_hilite, 'fenced_code'])
+        """
+        extensions = [self.hidden_hilite, 'fenced_code']
+        if self.has_pygments:
+            self.assert_renders("""
+        <div class="codehilite"><pre><span class="k">def</span>
+        </pre></div>
+        """, test_text, extensions)
+        else:
+            self.assert_renders("""
+        <pre class="codehilite"><code class="language-python">def</code></pre>
+        """, test_text, extensions)


### PR DESCRIPTION
Fixes #16. The cause is a lack of `pygments`.
`python-markdown` tries to import pygments. If it succeeded, markdown uses `pygments` to highlight codes.
https://github.com/waylan/Python-Markdown/blob/e594213ab689847ee7d9654817b8fa80fafb0fb7/markdown/extensions/codehilite.py#L23-29

In current version, it seems the testcases are for with pygments. After installing pygments, it doesn't fail.

in `python-markdown`, there are two tests; with `pygments` and without `pygments`.
https://github.com/waylan/Python-Markdown/blob/e594213ab689847ee7d9654817b8fa80fafb0fb7/tests/test_extensions.py#L92-97

I wrote the second testcase for failed ones.

    Note: I think it runs only one testcase, either with or without.
    if you have a better solution, please tell me.