### PR TITLE
Separate development requirements from setup.py

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+unittest2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     download_url='https://github.com/dart-lang/py-gfm/tarball/0.1.0',
     packages=find_packages(),
     include_package_data = True,
-    install_requires = ['setuptools', 'markdown', 'unittest2'],
+    install_requires = ['setuptools', 'markdown'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This makes it so that end users won't have to install unittest2 just to
install and use py-gfm.  (Even for developers, unittest2 should only be
needed if Python 2.6 support is desired.)