### PR TITLE
Add support for highly customizable, GitHub-like, task lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Support for GitHub-like task lists.
+
 ## 0.1.1
 
 * Support Python 3.

--- a/gfm/__init__.py
+++ b/gfm/__init__.py
@@ -8,6 +8,7 @@ from gfm import hidden_hilite
 from gfm import semi_sane_lists
 from gfm import spaced_link
 from gfm import strikethrough
+from gfm import tasklist
 
 AutolinkExtension = autolink.AutolinkExtension
 AutomailExtension = automail.AutomailExtension
@@ -15,3 +16,4 @@ HiddenHiliteExtension = hidden_hilite.HiddenHiliteExtension
 SemiSaneListExtension = semi_sane_lists.SemiSaneListExtension
 SpacedLinkExtension = spaced_link.SpacedLinkExtension
 StrikethroughExtension = strikethrough.StrikethroughExtension
+TaskListExtension = tasklist.TaskListExtension

--- a/gfm/tasklist.py
+++ b/gfm/tasklist.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+from __future__ import unicode_literals
+
+import markdown
+from functools import reduce
+from markdown.treeprocessors import Treeprocessor
+from markdown.util import etree
+
+try:
+    _string_type = unicode
+except NameError:
+    _string_type = str
+
+
+def _to_list(obj):
+    if isinstance(obj, _string_type):
+        return [obj]
+    if isinstance(obj, tuple):
+        return list(obj)
+    return obj
+
+
+class TaskListProcessor(Treeprocessor):
+    def __init__(self, ext):
+        super(TaskListProcessor, self).__init__()
+        self.ext = ext
+
+    def run(self, root):
+        ordered = self.ext.getConfig('ordered')
+        unordered = self.ext.getConfig('unordered')
+        if not ordered and not unordered:
+            return root
+
+        checked_pattern = _to_list(self.ext.getConfig('checked'))
+        unchecked_pattern = _to_list(self.ext.getConfig('unchecked'))
+        prefix_length = reduce(max, (len(e) for e in checked_pattern + unchecked_pattern))
+
+        item_attrs = self.ext.getConfig('item_attrs')
+        base_cb_attrs = self.ext.getConfig('checkbox_attrs')
+        max_depth = self.ext.getConfig('max_depth')
+        if not max_depth:
+            max_depth = float('inf')
+
+        stack = [(root, None, 0)]
+
+        while stack:
+            el, parent, depth = stack.pop()
+
+            if parent and el.tag == 'li' and (parent.tag == 'ul' and unordered or parent.tag == 'ol' and ordered):
+                depth += 1
+                text = (el.text or '').lstrip()
+                lower_text = text[:prefix_length].lower()
+                found = False
+                checked = False
+
+                for p in checked_pattern:
+                    if lower_text.startswith(p):
+                        found = True
+                        checked = True
+                        text = text[len(p):]
+                        break
+                else:
+                    for p in unchecked_pattern:
+                        if lower_text.startswith(p):
+                            found = True
+                            text = text[len(p):]
+                            break
+
+                if found:
+                    attrs = {'type': 'checkbox', 'disabled': 'disabled'}
+                    if checked:
+                        attrs['checked'] = 'checked'
+                    # Give user a chance to update attributes
+                    attrs.update(base_cb_attrs(parent, el) if callable(base_cb_attrs) else base_cb_attrs)
+                    checkbox = etree.Element('input', attrs)
+                    checkbox.tail = text
+                    el.text = ''
+                    el.insert(0, checkbox)
+                    # Give user a chance to update <li> attributes
+                    for k, v in (item_attrs(parent, el, checkbox) if callable(item_attrs) else item_attrs).items():
+                        el.set(k, v)
+
+            if depth < max_depth:
+                for child in el:
+                    stack.append((child, el, depth))
+
+        return root
+
+
+class TaskListExtension(markdown.Extension):
+    """
+    An extension that supports task lists, that are simply lists of checkboxes.
+    Both ordered and unordered lists are supported and can be separately
+    enabled. Nested lists are supported.
+
+    By default, unchecked boxes ares represented by [ ]. Customize the pattern
+    with option `unchecked`. You can use a list.
+    By default, checked boxes are represented by [x] or [X]. Customize the
+    pattern with option `checked`. You can use a list.
+    Checked patterns are tested before unchecked patterns.
+
+    Example:
+        - [x] milk
+        - [ ] eggs
+        - [x] chocolate
+        - [ ] if possible:
+            1. [ ] solve world peace
+            2. [ ] solve world hunger
+
+    Set option `unordered` to False to disable parsing of unordered lists.
+    Set option `ordered` to False to disable parsing of ordered lists.
+
+    You can limit the nesting of task lists by setting the `max_depth` option.
+    Default is unlimited nesting.
+
+    Option `item_attrs` accepts an attribute dict or a callable that takes the
+    following arguments:
+        - the <li> parent element
+        - the <li> element
+        - the generated <input type="checkbox"> element
+    and that should return an attribute dict.
+    These attributes are added to the <li> element where the checkbox is put.
+
+    Option `checkbox_attrs` accepts an attribute dict or a callable that takes
+    the following arguments:
+        - the <li> parent element
+        - the <li> element
+    and that should return an attribute dict.
+    These attributes are added to the checkbox element.
+
+    Note: Github has support for updating the markdown source by toggling the
+    checkbox (by clicking on it). This is not supported by this extension, as
+    it requires server-side processing that is out of scope of a markdown
+    parser.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.config = {
+            'ordered': [True, "Enable parsing of ordered lists"],
+            'unordered': [True, "Enable parsing of unordered lists"],
+            'checked': ['[x]', "The checked state pattern"],
+            'unchecked': ['[ ]', "The unchecked state pattern"],
+            'max_depth': [0, "Maximum list nesting depth (None for unlimited)"],
+            'item_attrs': [{}, "Additional attribute dict (or callable) to add to the <li> element"],
+            'checkbox_attrs': [{}, "Additional attribute dict (or callable) to add to the checkbox <input> element"],
+        }
+        super(TaskListExtension, self).__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md, md_globals):
+        processor = TaskListProcessor(self)
+        md.treeprocessors.add('gfm-tasklist', processor, '_end')

--- a/mdx_partial_gfm/__init__.py
+++ b/mdx_partial_gfm/__init__.py
@@ -42,3 +42,4 @@ class PartialGithubFlavoredMarkdownExtension(Extension):
         gfm.SemiSaneListExtension().extendMarkdown(md, md_globals)
         gfm.SpacedLinkExtension().extendMarkdown(md, md_globals)
         gfm.StrikethroughExtension().extendMarkdown(md, md_globals)
+        gfm.TaskListExtension().extendMarkdown(md, md_globals)

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='py-gfm',
-    version='0.1.1',
+    version='0.1.2',
     description='An implementation of Github-Flavored Markdown written as an extension to the Python Markdown library.',
     author='Dart Team',
     author_email='misc@dartlang.org',
     url='https://github.com/dart-lang/py-gfm',
-    download_url='https://github.com/dart-lang/py-gfm/tarball/0.1.0',
+    download_url='https://github.com/dart-lang/py-gfm/tarball/0.1.2',
     packages=find_packages(),
     include_package_data = True,
     install_requires = ['setuptools', 'markdown'],

--- a/test.py
+++ b/test.py
@@ -3,10 +3,10 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+from __future__ import unicode_literals
 import optparse
 import os
 import sys
-import subprocess
 
 from unittest import TextTestRunner
 
@@ -32,7 +32,7 @@ parser.add_option('-n', '--name', help='the name of the test to run',
 options, args = parser.parse_args()
 sdk_path = None
 if len(args) > 0:
-    print 'Error: 0 arguments expected.'
+    print('Error: 0 arguments expected.')
     parser.print_help()
     sys.exit(1)
 
@@ -40,4 +40,3 @@ test_path = os.path.join(os.path.dirname(__file__), 'tests')
 test_loader = loader.TestLoader()
 if options.name: test_loader.testMethodPrefix = options.name
 TextTestRunner(verbosity = 2).run(test_loader.discover(test_path))
-

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+import gfm
+
+from test_case import TestCase
+
+
+class TestTaskList(TestCase):
+    def setUp(self):
+        self.tasklist = gfm.TaskListExtension()
+        self.tasklist_ordered_disabled = gfm.TaskListExtension(ordered=False)
+        self.tasklist_patterns = gfm.TaskListExtension(checked=['~o', '[o]'],
+                                                       unchecked=['~', '[ ]'])
+        self.tasklist_max_depth = gfm.TaskListExtension(max_depth=2)
+        self.tasklist_item_attrs = gfm.TaskListExtension(item_attrs={'class': 'foo'})
+        self.tasklist_box_attrs = gfm.TaskListExtension(checkbox_attrs={'name': 'foo'})
+
+        def custom(parent, li):
+            return {'data-foo': li.text.split('=')[1]}
+        self.tasklist_box_attrs_cb = gfm.TaskListExtension(checkbox_attrs=custom)
+
+    def test_tasklist_nolist(self):
+        self.assert_renders("""
+        <p>Text</p>
+        <ul>
+        <li>first item</li>
+        </ul>
+        """, """
+        Text
+
+        - first item
+        """, [self.tasklist])
+
+    def test_tasklist_defaults(self):
+        self.assert_renders("""
+        <ul>
+        <li><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li>item</li>
+        <li><input disabled="disabled" type="checkbox" /> no item</li>
+        </ul>
+        """, """
+        - [x] yes item
+        - item
+        - [ ] no item
+        """, [self.tasklist])
+
+    def test_tasklist_ordered_list(self):
+        self.assert_renders("""
+        <ol>
+        <li><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li>item</li>
+        <li><input disabled="disabled" type="checkbox" /> no item</li>
+        </ol>
+        """, """
+        1. [x] yes item
+        1. item
+        1. [ ] no item
+        """, [self.tasklist])
+
+    def test_tasklist_whitespace(self):
+        self.assert_renders("""
+        <p>-[ ]not a list</p>
+        <ul>
+        <li><input disabled="disabled" type="checkbox" />item</li>
+        <li><input disabled="disabled" type="checkbox" /> item</li>
+        <li><input disabled="disabled" type="checkbox" />  item</li>
+        </ul>
+        """, """
+        -[ ]not a list
+
+        - [ ]item
+        -  [ ] item
+        -   [ ]  item
+        """, [self.tasklist])
+
+    def test_tasklist_disabled(self):
+        self.assert_renders("""
+        <ul>
+        <li><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li><input disabled="disabled" type="checkbox" /> no item</li>
+        </ul>
+        """, """
+        - [x] yes item
+        - [ ] no item
+        """, [self.tasklist_ordered_disabled])
+        self.assert_renders("""
+        <ol>
+        <li>[x] yes item</li>
+        <li>[ ] no item</li>
+        </ol>
+        """, """
+        1. [x] yes item
+        1. [ ] no item
+        """, [self.tasklist_ordered_disabled])
+
+    def test_tasklist_nested(self):
+        self.assert_renders("""
+        <ul>
+        <li><input disabled="disabled" type="checkbox" /> item<ul>
+        <li><input disabled="disabled" type="checkbox" /> nested</li>
+        <li><input disabled="disabled" type="checkbox" /> nested<ul>
+        <li><input disabled="disabled" type="checkbox" /> super nested</li>
+        </ul>
+        </li>
+        </ul>
+        </li>
+        </ul>
+        """, """
+        - [ ] item
+            - [ ] nested
+            - [ ] nested
+                - [ ] super nested
+        """, [self.tasklist])
+
+    def test_tasklist_custom_patterns(self):
+        self.assert_renders("""
+        <ul>
+        <li><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li><input disabled="disabled" type="checkbox" /> no item</li>
+        <li><input disabled="disabled" type="checkbox" /> no item</li>
+        <li>[x] item</li>
+        <li>item</li>
+        </ul>
+        """, """
+        - [o] yes item
+        - ~o yes item
+        - [ ] no item
+        - ~ no item
+        - [x] item
+        - item
+        """, [self.tasklist_patterns])
+
+    def test_tasklist_max_depth(self):
+        self.assert_renders("""
+        <ul>
+        <li><input disabled="disabled" type="checkbox" /> item<ul>
+        <li><input disabled="disabled" type="checkbox" /> nested 1<ul>
+        <li>[ ] super nested 1</li>
+        </ul>
+        </li>
+        <li><input disabled="disabled" type="checkbox" /> nested 2<ul>
+        <li>[ ] super nested 2</li>
+        </ul>
+        </li>
+        </ul>
+        </li>
+        </ul>
+        """, """
+        - [ ] item
+            - [ ] nested 1
+                - [ ] super nested 1
+            - [ ] nested 2
+                - [ ] super nested 2
+        """, [self.tasklist_max_depth])
+
+    def test_tasklist_item_attrs(self):
+        self.assert_renders("""
+        <ul>
+        <li class="foo"><input checked="checked" disabled="disabled" type="checkbox" /> yes item</li>
+        <li class="foo"><input disabled="disabled" type="checkbox" /> no item</li>
+        </ul>
+        """, """
+        - [x] yes item
+        - [ ] no item
+        """, [self.tasklist_item_attrs])
+
+    def test_tasklist_box_attrs(self):
+        self.assert_renders("""
+        <ul>
+        <li><input checked="checked" disabled="disabled" name="foo" type="checkbox" /> yes item</li>
+        <li><input disabled="disabled" name="foo" type="checkbox" /> no item</li>
+        </ul>
+        """, """
+        - [x] yes item
+        - [ ] no item
+        """, [self.tasklist_box_attrs])
+
+    def test_tasklist_box_attrs_cb(self):
+        self.assert_renders("""
+        <ul>
+        <li><input checked="checked" data-foo="42" disabled="disabled" type="checkbox" /> foo =42</li>
+        <li><input data-foo="1337" disabled="disabled" type="checkbox" /> foo =1337</li>
+        </ul>
+        """, """
+        - [x] foo =42
+        - [ ] foo =1337
+        """, [self.tasklist_box_attrs_cb])


### PR DESCRIPTION
Fixes #1.
I am not sure about the copyright heading you want me to use. Feel free to request a modification.
Code was tested on Python 2.7, 3.4 and 3.5. I had to make minor changes in `test.py` to that end.

---

An extension that supports task lists, that are simply lists of checkboxes. Both ordered and unordered lists are supported and can be separately enabled. Nested lists are supported.

By default, unchecked boxes ares represented by `[ ]`. Customize the pattern with option `unchecked`. You can use a list.
By default, checked boxes are represented by `[x]` or `[X]`. Customize the pattern with option `checked`. You can use a list.
Checked patterns are tested before unchecked patterns.

Example:

```
- [x] milk
- [ ] eggs
- [x] chocolate
- [ ] if possible:
    1. [ ] solve world peace
    2. [ ] solve world hunger
```

Set option `unordered` to False to disable parsing of unordered lists.
Set option `ordered` to False to disable parsing of ordered lists.

You can limit the nesting of task lists by setting the `max_depth` option. Default is unlimited nesting.

Option `item_attrs` accepts an attribute dict or a callable that takes the following arguments:
- the `<li>` parent element
- the `<li>` element
- the generated `<input type="checkbox">` element

and that should return an attribute dict.
These attributes are added to the `<li>` element where the checkbox is put.

Option `checkbox_attrs` accepts an attribute dict or a callable that takes
the following arguments:
- the `<li>` parent element
- the `<li>` element

and that should return an attribute dict.
These attributes are added to the checkbox element.

Note: Github has support for updating the markdown source by toggling the checkbox (by clicking on it). This is not supported by this extension, as it requires server-side processing that is out of scope of a markdown parser.
