### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+
+cache: pip
+
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+
+install:
+  - pip install -r dev-requirements.txt
+  - pip install .
+
+script: python test.py
+

--- a/test.py
+++ b/test.py
@@ -3,10 +3,10 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-import optparse
+from __future__ import unicode_literals
+import argparse
 import os
 import sys
-import subprocess
 
 from unittest import TextTestRunner
 
@@ -22,22 +22,16 @@ try:
 except ImportError:
     from unittest2 import loader
 
-USAGE = """%prog
-Run unit tests."""
+parser = argparse.ArgumentParser("Run unit tests.")
+parser.add_argument('-n', '--name', help='the name of the test to run',
+                    metavar='NAME')
 
-parser = optparse.OptionParser(USAGE)
-parser.add_option('-n', '--name', help='the name of the test to run',
-                  metavar='NAME')
-
-options, args = parser.parse_args()
-sdk_path = None
-if len(args) > 0:
-    print 'Error: 0 arguments expected.'
-    parser.print_help()
-    sys.exit(1)
+args = parser.parse_args()
 
 test_path = os.path.join(os.path.dirname(__file__), 'tests')
 test_loader = loader.TestLoader()
-if options.name: test_loader.testMethodPrefix = options.name
-TextTestRunner(verbosity = 2).run(test_loader.discover(test_path))
+if args.name:
+    test_loader.testMethodPrefix = args.name
 
+result = TextTestRunner(verbosity=2).run(test_loader.discover(test_path))
+sys.exit(len(result.errors) + len(result.failures))


### PR DESCRIPTION
You may want to include Python 2.6 too, but at the moment the build fails for some obscure reason (`importlib` not found when importing markdown itself).
